### PR TITLE
Use more convenient types

### DIFF
--- a/compare/Main.hs
+++ b/compare/Main.hs
@@ -60,7 +60,7 @@ bgroupN f n = bgroup (show n) $
 
 bgroupIOA :: Ord a => String -> IO (IOArray a) -> Benchmark
 bgroupIOA name mkma = bgroup name
-  [ bench "samsort sortArrayBy#" $
+  [ bench "samsort sortArrayBy" $
     perRunEnv (fmap WHNF mkma) $ \(WHNF ma) -> samSort ma
   , bench "vector-algorithms Intro" $
     perRunEnv mkmv $ \(WHNF mv) -> Intro.sort mv
@@ -91,7 +91,7 @@ bgroupPN n = bgroup (show n) $
 
 bgroupIOPA :: String -> IO (IOPrimArray Int) -> Benchmark
 bgroupIOPA name mkma = bgroup name
-  [ bench "samsort sortIntArrayBy#" $
+  [ bench "samsort sortIntArrayBy" $
     perRunEnv (fmap WHNF mkma) $ \(WHNF ma) -> samSortInts ma
   , bench "vector-algorithms Intro" $
     perRunEnv mkmv $ \(WHNF mv) -> Intro.sort mv

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -21,11 +21,11 @@ import Data.SamSort (sortArrayBy, sortIntArrayBy)
 
 main :: IO ()
 main = defaultMain $ localOption (QuickCheckTests 5000) $ testGroup "Tests"
-  [ testProperty "sortArrayBy#" $ \xs ys zs ->
+  [ testProperty "sortArrayBy" $ \xs ys zs ->
       sortViaMutableArray (comparing fst) (xs,ys,zs)
       ===
       ((xs :: [(OrdA, A)]) ++ L.sortBy (comparing fst) ys ++ zs)
-  , testProperty "sortIntArrayBy#" $ \f xs ys zs ->
+  , testProperty "sortIntArrayBy" $ \f xs ys zs ->
       sortViaMutableIntArray
         (comparing (applyFun (f :: Fun Int OrdA)))
         (xs,ys,zs)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -13,6 +13,7 @@ import Data.Primitive.PrimArray
   , sizeofPrimArray
   , thawPrimArray
   )
+
 import Test.Tasty (defaultMain, localOption, testGroup)
 import Test.Tasty.QuickCheck (QuickCheckTests(..), Fun, applyFun, testProperty, (===))
 import Test.QuickCheck.Poly (A, OrdA)


### PR DESCRIPTION
This is a move away from the bare `GHC.Exts` style towards the `primitive` style.
The sort functions take `Int`s now, and return `ST`.
I expect this to make the library more convenient to use.